### PR TITLE
Fix Deployment Strategy

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,16 @@
 name: NPM Registry Publish
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,11 +29,11 @@ jobs:
       - name: Build project
         run: npm run build
 
-      - name: Version patch and push
+      - name: Version bump and push
         run: |
           git config user.name "${{ secrets.ACTION_GIT_USER_NAME }}"
           git config user.email "${{ secrets.ACTION_GIT_USER_EMAIL }}"
-          yarn version --patch -m "chore(release): %s"
+          yarn version --${{ github.event.inputs.version_type }} -m "chore(release): %s"
           git push origin HEAD
       - name: Publish to registry
         env:


### PR DESCRIPTION
- Modify previous deployment Strategy due to it's limitations
  - The existing method only allows patch updates and has limitations in that it does not allow branching between major, minor, and patch.